### PR TITLE
Mantid versions: latest & nightly

### DIFF
--- a/autoreduce_rest_api/autoreduce_django/fixtures/software_fixture.json
+++ b/autoreduce_rest_api/autoreduce_django/fixtures/software_fixture.json
@@ -4,7 +4,15 @@
         "pk": 1,
         "fields": {
             "name": "Mantid",
-            "version": "6.4.0"
+            "version": "latest"
+        }
+    },
+    {
+        "model": "reduction_viewer.software",
+        "pk": 2,
+        "fields": {
+            "name": "Mantid",
+            "version": "nightly"
         }
     }
 ]

--- a/autoreduce_rest_api/runs/test/test_submit_runs.py
+++ b/autoreduce_rest_api/runs/test/test_submit_runs.py
@@ -118,7 +118,7 @@ class SubmitRunsTest(LiveServerTestCase):
                                      "runs": list(range(63125, 63131)),
                                      "software": {
                                          "name": "Mantid",
-                                         "version": "6.4.0"
+                                         "version": "latest"
                                      },
                                  },
                                  headers={"Authorization": f"Token {self.token}"})
@@ -148,7 +148,7 @@ class SubmitRunsTest(LiveServerTestCase):
                                      "runs": [63125, 63130],
                                      "software": {
                                          "name": "Mantid",
-                                         "version": "6.4.0"
+                                         "version": "latest"
                                      },
                                      "reduction_arguments": {
                                          "standard_vars": {

--- a/autoreduce_rest_api/runs/views.py
+++ b/autoreduce_rest_api/runs/views.py
@@ -10,12 +10,11 @@ from autoreduce_db.reduction_viewer.models import Software
 
 def get_common_args_from_request(request):
     """Gets common arguments that are used in all POST views"""
-    latest_mantid = Software.objects.filter(name='Mantid').order_by('-version')[0]
     return (request.data.get("reduction_arguments", {}), request.data.get("user_id",
                                                                           -1), request.data.get("description", ""),
             request.data.get("software", {
-                "name": latest_mantid.name,
-                "version": latest_mantid.version
+                "name": "Mantid",
+                "version": "latest"
             }))
 
 

--- a/autoreduce_rest_api/runs/views.py
+++ b/autoreduce_rest_api/runs/views.py
@@ -11,9 +11,9 @@ def get_common_args_from_request(request):
     """Gets common arguments that are used in all POST views"""
     return (request.data.get("reduction_arguments", {}), request.data.get("user_id", -1),
             request.data.get("description", ""), request.data.get("software", {
-                 "name": "Mantid",
-                 "version": "latest"
-             }))
+                "name": "Mantid",
+                "version": "latest"
+            }))
 
 
 NO_RUNS_KEY_MESSAGE = "No 'runs' key specified"

--- a/autoreduce_rest_api/runs/views.py
+++ b/autoreduce_rest_api/runs/views.py
@@ -9,12 +9,11 @@ from autoreduce_scripts.manual_operations.manual_remove import main as remove_ma
 
 def get_common_args_from_request(request):
     """Gets common arguments that are used in all POST views"""
-    return (request.data.get("reduction_arguments", {}), request.data.get("user_id",
-                                                                          -1), request.data.get("description", ""),
-            request.data.get("software", {
-                "name": "Mantid",
-                "version": "latest"
-            }))
+    return (request.data.get("reduction_arguments", {}), request.data.get("user_id", -1),
+            request.data.get("description", ""), request.data.get("software", {
+                 "name": "Mantid",
+                 "version": "latest"
+             }))
 
 
 NO_RUNS_KEY_MESSAGE = "No 'runs' key specified"

--- a/autoreduce_rest_api/runs/views.py
+++ b/autoreduce_rest_api/runs/views.py
@@ -5,7 +5,6 @@ from rest_framework import authentication, permissions
 from autoreduce_scripts.manual_operations.manual_submission import main as submit_main
 from autoreduce_scripts.manual_operations.manual_batch_submit import main as submit_batch_main
 from autoreduce_scripts.manual_operations.manual_remove import main as remove_main
-from autoreduce_db.reduction_viewer.models import Software
 
 
 def get_common_args_from_request(request):


### PR DESCRIPTION
### Summary of work

- Change the default Mantid version to be used if no software version is passed to API (this happens if run-detection passes message as opposed to frontend)
- Default is now Mantid Latest