### PR TITLE
Switch from Gunicorn to Django Hurricane

### DIFF
--- a/autoreduce_rest_api/autoreduce_django/settings.py
+++ b/autoreduce_rest_api/autoreduce_django/settings.py
@@ -38,9 +38,16 @@ else:
 # Application definition
 
 INSTALLED_APPS = [
-    'django.contrib.auth', 'django.contrib.contenttypes', 'django.contrib.sessions', 'django.contrib.messages',
-    'autoreduce_db.reduction_viewer', 'autoreduce_db.instrument', 'rest_framework', 'rest_framework.authtoken',
-    'autoreduce_rest_api.runs', 'hurricane',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'autoreduce_db.reduction_viewer',
+    'autoreduce_db.instrument',
+    'rest_framework',
+    'rest_framework.authtoken',
+    'autoreduce_rest_api.runs',
+    'hurricane',
 ]
 
 if os.environ.get("TESTING_MYSQL_DB", None) is not None:

--- a/autoreduce_rest_api/autoreduce_django/settings.py
+++ b/autoreduce_rest_api/autoreduce_django/settings.py
@@ -40,7 +40,7 @@ else:
 INSTALLED_APPS = [
     'django.contrib.auth', 'django.contrib.contenttypes', 'django.contrib.sessions', 'django.contrib.messages',
     'autoreduce_db.reduction_viewer', 'autoreduce_db.instrument', 'rest_framework', 'rest_framework.authtoken',
-    'autoreduce_rest_api.runs'
+    'autoreduce_rest_api.runs', 'hurricane',
 ]
 
 if os.environ.get("TESTING_MYSQL_DB", None) is not None:

--- a/container/rest-api.D
+++ b/container/rest-api.D
@@ -1,9 +1,7 @@
 FROM ghcr.io/autoreduction/base
 
-RUN python3 -m pip install --user --no-cache-dir gunicorn
-
 # Installs rest-api from your local repository
 ADD . .
 RUN python3 -m pip install --user --no-cache-dir .
 
-CMD ["gunicorn", "--bind", "0.0.0.0:8001", "--workers", "4", "autoreduce_rest_api.autoreduce_django.wsgi"]
+CMD ["autoreduce-rest-api-manage", "serve", "--port", "8004"]

--- a/container/rest-api.D
+++ b/container/rest-api.D
@@ -4,4 +4,4 @@ FROM ghcr.io/autoreduction/base
 ADD . .
 RUN python3 -m pip install --user --no-cache-dir .
 
-CMD ["autoreduce-rest-api-manage", "serve", "--port", "8004"]
+CMD ["autoreduce-rest-api-manage", "serve", "--port", "8001", "--probe-port", "8005"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "autoreduce_scripts==22.0.0.dev43",
     "Django",
     "djangorestframework==3.13.1",
+    "django-hurricane",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
### Summary of work
Replace Gunicorn with [Hurricane](https://github.com/django-hurricane/django-hurricane) for hosting the web server.

Hurricane includes built-in Probe endpoints, which will be useful for including livenessProbes and readinessProbes in the Kubernetes deployments of the frontend and rest-api.
