### PR TITLE
Use the DJANGO_SECRET_ENV environment variable for key

### DIFF
--- a/autoreduce_rest_api/autoreduce_django/settings.py
+++ b/autoreduce_rest_api/autoreduce_django/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-sm6+=6-6b=r+h4vwi23gs+n(u=o4aji74u^v6$48ed#+$fjn!f'
+SECRET_KEY = os.getenv('DJANGO_SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = "AUTOREDUCTION_PRODUCTION" not in os.environ


### PR DESCRIPTION
### Summary of work
<!---The changes you have made--->
I checked that the queue-processor has the DJANGO_SECRET_ENV environment variable, in the k8s repo we have a secrets file [here](https://github.com/autoreduction/k8s/blob/b50f70f6506a6c3eab2d688713008e473f00191a/ansible/roles/frontend/templates/webapp-secret.yaml#L8), and that is given the queue-processor in the k8s repo as well as a secretRef in this [file](https://github.com/autoreduction/k8s/blob/b50f70f6506a6c3eab2d688713008e473f00191a/ansible/roles/rest_api/templates/deployment.yaml#L31)

### How to test your work
<!---This can be a link to the--->
Code review

### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?--->

Fixes #[1483](https://github.com/autoreduction/queue-processor/issues/1483)


**Before merging ensure the release notes have been updated**
